### PR TITLE
change zh_tw LanguageName to prevent collision

### DIFF
--- a/Translations/Interface/正體中文-台灣.json
+++ b/Translations/Interface/正體中文-台灣.json
@@ -1,6 +1,6 @@
 {
   "$type": "Catchem.UiTranslation.UiTranslation, Catchem",
-  "LanguageName": "Chinese",
+  "LanguageName": "正體中文",
   "Translation": {
     "$type": "System.Collections.Generic.Dictionary`2[[System.String, mscorlib],[System.String, mscorlib]], mscorlib",
     "%AUTOSTART%": "自動啟動",


### PR DESCRIPTION
prevent name collision with "Chinese" in [简体中文.json](https://github.com/Lunat1q/Catchem-PoGo/blob/master/Translations/Interface/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87.json)